### PR TITLE
Break and Continue

### DIFF
--- a/src/main/kotlin/compiler/Optimizer.kt
+++ b/src/main/kotlin/compiler/Optimizer.kt
@@ -142,8 +142,9 @@ class Optimizer(private val coder: Coder) {
         val nulls = mutableListOf<VMWord>()
         opcodes.forEachIndexed { i, t ->
             if (t == null) nulls.add(mem[pc + i])
-            else if (i > 0 && (pc + i) in jumpMap.keys) hit = false  // Miss if we overlap a jump dest
-            else if (mem[pc + i].opcode != t) hit = false  // Miss if opcode doesn't match
+            else if (mem[pc + i].opcode != t) hit = false
+            // Miss if we're going to wipe out a jump dest
+            else if (i > 0 && ((pc + i) in jumpMap.keys)) hit = false
         }
         if (hit && (check?.invoke(nulls) != false)) {
             pc += opcodes.size

--- a/src/main/kotlin/compiler/Optimizer.kt
+++ b/src/main/kotlin/compiler/Optimizer.kt
@@ -30,7 +30,7 @@ class Optimizer(private val coder: Coder) {
         while (pc < mem.size) {
             // If we've reached a jump dest, record its new address
             if (jumpMap.containsKey(pc)) jumpMap[pc] = outMem.size
-            // If we've reached an entry point, record its new address
+            // If we've reached a block boundary, record its new address
             coder.blocks.forEachIndexed { n, it ->
                 if (it.start == pc) blockStarts[n] = outMem.size
                 if (it.end == pc) blockEnds[n] = outMem.size
@@ -115,9 +115,15 @@ class Optimizer(private val coder: Coder) {
         }
 
         // Replace all jump dests
+        val alreadyFilled = mutableSetOf<Int>()
         jumpMap.keys.forEach { old ->
-            outMem.forEach { word ->
-                if (word.address == old) word.address = jumpMap[old]
+            outMem.forEachIndexed { pc, word ->
+                if (!alreadyFilled.contains(pc)) {
+                    if (word.address == old) {
+                        word.address = jumpMap[old]
+                        alreadyFilled.add(pc)
+                    }
+                }
             }
         }
         // Replace all block addresses
@@ -136,8 +142,8 @@ class Optimizer(private val coder: Coder) {
         val nulls = mutableListOf<VMWord>()
         opcodes.forEachIndexed { i, t ->
             if (t == null) nulls.add(mem[pc + i])
-            else if ((pc + i) in jumpMap.keys) hit = false  // Miss if we overlap a jump dest
-            else if (mem[pc + i].opcode != t) hit = false
+            else if (i > 0 && (pc + i) in jumpMap.keys) hit = false  // Miss if we overlap a jump dest
+            else if (mem[pc + i].opcode != t) hit = false  // Miss if opcode doesn't match
         }
         if (hit && (check?.invoke(nulls) != false)) {
             pc += opcodes.size

--- a/src/main/kotlin/compiler/ast/statement/N_BREAK.kt
+++ b/src/main/kotlin/compiler/ast/statement/N_BREAK.kt
@@ -1,0 +1,13 @@
+package com.dlfsystems.compiler.ast.statement
+
+import com.dlfsystems.compiler.Coder
+import com.dlfsystems.vm.Opcode.*
+
+class N_BREAK: N_STATEMENT() {
+    override fun toText() = "break"
+
+    override fun code(coder: Coder) {
+        coder.code(this, O_JUMP)
+        coder.jumpBreak(this)
+    }
+}

--- a/src/main/kotlin/compiler/ast/statement/N_CONTINUE.kt
+++ b/src/main/kotlin/compiler/ast/statement/N_CONTINUE.kt
@@ -1,0 +1,13 @@
+package com.dlfsystems.compiler.ast.statement
+
+import com.dlfsystems.compiler.Coder
+import com.dlfsystems.vm.Opcode.*
+
+class N_CONTINUE: N_STATEMENT() {
+    override fun toText() = "continue"
+
+    override fun code(coder: Coder) {
+        coder.code(this, O_JUMP)
+        coder.jumpContinue(this)
+    }
+}

--- a/src/main/kotlin/compiler/ast/statement/N_FOR.kt
+++ b/src/main/kotlin/compiler/ast/statement/N_FOR.kt
@@ -11,6 +11,7 @@ class N_FORLOOP(val assign: N_STATEMENT, val check: N_EXPR, val increment: N_STA
     override fun kids() = listOf(assign, check, increment, body)
 
     override fun code(coder: Coder) {
+        coder.pushBreakStack()
         assign.code(coder)
         coder.setBackJump(this, "forStart")
         check.code(coder)
@@ -21,6 +22,7 @@ class N_FORLOOP(val assign: N_STATEMENT, val check: N_EXPR, val increment: N_STA
         coder.code(this, O_JUMP)
         coder.jumpBack(this, "forStart")
         coder.setForwardJump(this, "forEnd")
+        coder.setBreakJump()
     }
 }
 
@@ -33,6 +35,7 @@ class N_FORVALUE(val index: N_IDENTIFIER, val source: N_EXPR, val body: N_STATEM
     override fun kids() = listOf(index, internalIndex, source, internalSource, body)
 
     override fun code(coder: Coder) {
+        coder.pushBreakStack()
         coder.code(this, O_VAL)
         coder.value(this, 0)
         coder.code(this, O_SETVAR)
@@ -57,17 +60,19 @@ class N_FORVALUE(val index: N_IDENTIFIER, val source: N_EXPR, val body: N_STATEM
         coder.code(this, O_CMP_LE)
         coder.code(this, O_IF)
         coder.jumpBack(this, "forStart")
+        coder.setBreakJump()
     }
 }
 
 class N_FORRANGE(val index: N_IDENTIFIER, val from: N_EXPR, val to: N_EXPR, val body: N_STATEMENT): N_STATEMENT() {
-    private val internalTo = N_IDENTIFIER(makeID().toString())
+    private val internalTo = N_IDENTIFIER(makeID())
 
     override fun toText(depth: Int) = tab(depth) + "for ($index in $from..$to) " + body.toText(depth + 1)
     override fun toText() = toText(0)
     override fun kids() = listOf(index, from, to, internalTo, body)
 
     override fun code(coder: Coder) {
+        coder.pushBreakStack()
         to.code(coder)
         coder.code(this, O_SETVAR)
         coder.value(this, internalTo.variableID!!)
@@ -85,5 +90,6 @@ class N_FORRANGE(val index: N_IDENTIFIER, val from: N_EXPR, val to: N_EXPR, val 
         coder.code(this, O_CMP_LT)
         coder.code(this, O_IF)
         coder.jumpBack(this, "forStart")
+        coder.setBreakJump()
     }
 }

--- a/src/main/kotlin/compiler/ast/statement/N_FOR.kt
+++ b/src/main/kotlin/compiler/ast/statement/N_FOR.kt
@@ -11,13 +11,14 @@ class N_FORLOOP(val assign: N_STATEMENT, val check: N_EXPR, val increment: N_STA
     override fun kids() = listOf(assign, check, increment, body)
 
     override fun code(coder: Coder) {
-        coder.pushBreakStack()
+        coder.pushLoopStack()
         assign.code(coder)
         coder.setBackJump(this, "forStart")
         check.code(coder)
         coder.code(this, O_IF)
         coder.jumpForward(this, "forEnd")
         body.code(coder)
+        coder.setContinueJump()
         increment.code(coder)
         coder.code(this, O_JUMP)
         coder.jumpBack(this, "forStart")
@@ -35,7 +36,7 @@ class N_FORVALUE(val index: N_IDENTIFIER, val source: N_EXPR, val body: N_STATEM
     override fun kids() = listOf(index, internalIndex, source, internalSource, body)
 
     override fun code(coder: Coder) {
-        coder.pushBreakStack()
+        coder.pushLoopStack()
         coder.code(this, O_VAL)
         coder.value(this, 0)
         coder.code(this, O_SETVAR)
@@ -50,6 +51,7 @@ class N_FORVALUE(val index: N_IDENTIFIER, val source: N_EXPR, val body: N_STATEM
         coder.code(this, O_SETVAR)
         coder.value(this, index.variableID!!)
         body.code(coder)
+        coder.setContinueJump()
         coder.code(this, O_INCVAR)
         coder.value(this, internalIndex.variableID!!)
         coder.code(this, O_GETVAR)
@@ -72,7 +74,7 @@ class N_FORRANGE(val index: N_IDENTIFIER, val from: N_EXPR, val to: N_EXPR, val 
     override fun kids() = listOf(index, from, to, internalTo, body)
 
     override fun code(coder: Coder) {
-        coder.pushBreakStack()
+        coder.pushLoopStack()
         to.code(coder)
         coder.code(this, O_SETVAR)
         coder.value(this, internalTo.variableID!!)
@@ -81,6 +83,7 @@ class N_FORRANGE(val index: N_IDENTIFIER, val from: N_EXPR, val to: N_EXPR, val 
         coder.value(this, index.variableID!!)
         coder.setBackJump(this, "forStart")
         body.code(coder)
+        coder.setContinueJump()
         coder.code(this, O_INCVAR)
         coder.value(this, index.variableID!!)
         coder.code(this, O_GETVAR)

--- a/src/main/kotlin/compiler/ast/statement/N_WHILE.kt
+++ b/src/main/kotlin/compiler/ast/statement/N_WHILE.kt
@@ -11,6 +11,7 @@ class N_WHILE(val check: N_EXPR, val body: N_STATEMENT): N_STATEMENT() {
     override fun kids() = listOf(check, body)
 
     override fun code(coder: Coder) {
+        coder.pushBreakStack()
         coder.setBackJump(this, "whileStart")
         check.code(coder)
         coder.code(this, O_IF)
@@ -19,5 +20,6 @@ class N_WHILE(val check: N_EXPR, val body: N_STATEMENT): N_STATEMENT() {
         coder.code(this, O_JUMP)
         coder.jumpBack(this, "whileStart")
         coder.setForwardJump(this, "whileEnd")
+        coder.setBreakJump()
     }
 }

--- a/src/main/kotlin/compiler/ast/statement/N_WHILE.kt
+++ b/src/main/kotlin/compiler/ast/statement/N_WHILE.kt
@@ -11,12 +11,13 @@ class N_WHILE(val check: N_EXPR, val body: N_STATEMENT): N_STATEMENT() {
     override fun kids() = listOf(check, body)
 
     override fun code(coder: Coder) {
-        coder.pushBreakStack()
+        coder.pushLoopStack()
         coder.setBackJump(this, "whileStart")
         check.code(coder)
         coder.code(this, O_IF)
         coder.jumpForward(this, "whileEnd")
         body.code(coder)
+        coder.setContinueJump()
         coder.code(this, O_JUMP)
         coder.jumpBack(this, "whileStart")
         coder.setForwardJump(this, "whileEnd")

--- a/src/main/kotlin/compiler/parser/Lexer.kt
+++ b/src/main/kotlin/compiler/parser/Lexer.kt
@@ -127,7 +127,7 @@ class Lexer(val source: String) {
                     emit(T_DOTDOT)
                 }
                 in '0'..'9' -> accumulate(c)
-                else -> fail("incomplete float")
+                else -> if (tokenString.endsWith('.')) fail("incomplete float") else emit(T_FLOAT, c)
             }
             T_OBJREF -> {
                 if (isIDChar(c)) accumulate(c) else emit(T_OBJREF, c)

--- a/src/main/kotlin/compiler/parser/Parser.kt
+++ b/src/main/kotlin/compiler/parser/Parser.kt
@@ -79,6 +79,7 @@ class Parser(inputTokens: List<Token>) {
     // Parse any statement type we find next.
     private fun pStatement(): N_STATEMENT? {
         pBlock()?.also { return it }
+        pBreak()?.also { return it }
         pIfElse()?.also { return it }
         pForLoop()?.also { return it }
         pWhile()?.also { return it }
@@ -106,6 +107,11 @@ class Parser(inputTokens: List<Token>) {
             1 -> node(statements[0])
             else -> node(N_BLOCK(statements))
         }
+    }
+
+    private fun pBreak(): N_STATEMENT? {
+        consume(T_BREAK) ?: return null
+        return node(N_BREAK())
     }
 
     // Parse: if <expr> <statement> [else <statement>]

--- a/src/main/kotlin/compiler/parser/Parser.kt
+++ b/src/main/kotlin/compiler/parser/Parser.kt
@@ -80,6 +80,7 @@ class Parser(inputTokens: List<Token>) {
     private fun pStatement(): N_STATEMENT? {
         pBlock()?.also { return it }
         pBreak()?.also { return it }
+        pContinue()?.also { return it }
         pIfElse()?.also { return it }
         pForLoop()?.also { return it }
         pWhile()?.also { return it }
@@ -112,6 +113,11 @@ class Parser(inputTokens: List<Token>) {
     private fun pBreak(): N_STATEMENT? {
         consume(T_BREAK) ?: return null
         return node(N_BREAK())
+    }
+
+    private fun pContinue(): N_STATEMENT? {
+        consume(T_CONTINUE) ?: return null
+        return node(N_CONTINUE())
     }
 
     // Parse: if <expr> <statement> [else <statement>]

--- a/src/main/kotlin/compiler/parser/Token.kt
+++ b/src/main/kotlin/compiler/parser/Token.kt
@@ -59,7 +59,6 @@ enum class TokenType(val literal: String, val isKeyword: Boolean = false) {
     T_FOR("for", true),
     T_IF("if", true),
     T_IN("in", true),
-    T_NULL("null", true),
     T_OR("or", true),
     T_RETURN("return", true),
     T_TRUE("true", true),
@@ -68,6 +67,8 @@ enum class TokenType(val literal: String, val isKeyword: Boolean = false) {
     T_WHEN("when", true),
     T_SUSPEND("suspend", true),
     T_FORK("fork", true),
+    T_BREAK("break", true),
+    T_CONTINUE("continue", true),
 
     T_EOF("EOF");
 }


### PR DESCRIPTION
Adds 'break' and 'continue' statements to for/while loops.

Keeping things straight in nested loops was the trick here.  We make a stack on Coder for break jumps, and another for continue jumps.  Each stack entry is a list of word addresses where we JUMP to the break/continue point for that loop.

When a loop starts coding, it pushes on both stacks.  Any break/continue codes a jump recorded in the top list of the break (or continue) stack.  When the loop registers its break/continue jump points, it pops the stacks (and writes the addresses to the stored locations).

Also fixes an (unrelated) bug I discovered in Optimizer while testing.  (I was accidentally over-writing updated jump addresses multiple times if they happened to collide.)

```
foo = 0
notifyConn("Start $foo.")
while (foo < 100) {
	if (foo > 4) break
	for (i in 0..3) {
		if (i == 1) continue
		notifyConn("foo=$foo i=$i")
	}
	foo++
}
notifyConn("Done.")
```

```
< Start 0.
< foo=0 i=0
< foo=0 i=2
< foo=0 i=3
< foo=1 i=0
< foo=1 i=2
< foo=1 i=3
< foo=2 i=0
< foo=2 i=2
< foo=2 i=3
< foo=3 i=0
< foo=3 i=2
< foo=3 i=3
< foo=4 i=0
< foo=4 i=2
< foo=4 i=3
< Done.
```
