### PR TITLE
Short-circuit logical AND + OR

### DIFF
--- a/src/main/kotlin/compiler/ast/expr/N_BINOP.kt
+++ b/src/main/kotlin/compiler/ast/expr/N_BINOP.kt
@@ -47,8 +47,7 @@ class N_POWER(left: N_EXPR, right: N_EXPR): N_BINOP("^", left, right, listOf(O_P
 class N_MODULUS(left: N_EXPR, right: N_EXPR): N_BINOP("%", left, right, listOf(O_MODULUS)) {
     override fun asConstant(l: Value, r: Value) = l.modulo(r)
 }
-class N_AND(left: N_EXPR, right: N_EXPR): N_BINOP("&&", left, right, listOf(O_AND))
-class N_OR(left: N_EXPR, right: N_EXPR): N_BINOP("||", left, right, listOf(O_OR))
+
 class N_IN(left: N_EXPR, right: N_EXPR): N_BINOP("in", left, right, listOf(O_IN))
 
 class N_CMP_EQ(left: N_EXPR, right: N_EXPR): N_BINOP("==", left, right, listOf(O_CMP_EQ))
@@ -57,3 +56,24 @@ class N_CMP_GT(left: N_EXPR, right: N_EXPR): N_BINOP(">", left, right, listOf(O_
 class N_CMP_LT(left: N_EXPR, right: N_EXPR): N_BINOP("<", left, right, listOf(O_CMP_LT))
 class N_CMP_GE(left: N_EXPR, right: N_EXPR): N_BINOP(">=", left, right, listOf(O_CMP_GE))
 class N_CMP_LE(left: N_EXPR, right: N_EXPR): N_BINOP("<=", left, right, listOf(O_CMP_LE))
+
+class N_AND(left: N_EXPR, right: N_EXPR): N_BINOP("&&", left, right, listOf(O_AND)) {
+    override fun code(coder: Coder) {
+        left.code(coder)
+        coder.code(this, O_IF)
+        coder.jumpForward(this, "andskip")
+        right.code(coder)
+        coder.setForwardJump(this, "andskip")
+    }
+}
+
+class N_OR(left: N_EXPR, right: N_EXPR): N_BINOP("||", left, right, listOf(O_OR)) {
+    override fun code(coder: Coder) {
+        left.code(coder)
+        coder.code(this, O_NEGATE)
+        coder.code(this, O_IF)
+        coder.jumpForward(this, "orskip")
+        right.code(coder)
+        coder.setForwardJump(this, "orskip")
+    }
+}

--- a/src/main/kotlin/compiler/parser/Parser.kt
+++ b/src/main/kotlin/compiler/parser/Parser.kt
@@ -367,10 +367,10 @@ class Parser(inputTokens: List<Token>) {
     private fun pAndOr(): N_EXPR? {
         val next = this::pConditional
         var left = next() ?: return null
-        while (nextIs(T_AND, T_OR)) {
+        while (nextIs(T_LOGIC_AND, T_LOGIC_OR)) {
             val operator = consume()
             next()?.also { right ->
-                left = node(if (operator.type == T_AND) N_AND(left, right)
+                left = node(if (operator.type == T_LOGIC_AND) N_AND(left, right)
                             else N_OR(left, right)
                 )
             }

--- a/src/main/kotlin/compiler/parser/Token.kt
+++ b/src/main/kotlin/compiler/parser/Token.kt
@@ -53,13 +53,11 @@ enum class TokenType(val literal: String, val isKeyword: Boolean = false) {
     T_OBJREF("#xxxxx"),
 
     // Keywords
-    T_AND("and", true),
     T_ELSE("else", true),
     T_FALSE("false", true),
     T_FOR("for", true),
     T_IF("if", true),
     T_IN("in", true),
-    T_OR("or", true),
     T_RETURN("return", true),
     T_TRUE("true", true),
     T_WHILE("while", true),

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -329,13 +329,11 @@ class VM(
                 }
                 O_AND -> {
                     val (a2, a1) = popTwo()
-                    if (a1 is VBool && a2 is VBool) push(VBool(a1.v && a2.v))
-                    else fail(E_TYPE, "cannot AND ${a1.type} and ${a2.type}")
+                    push(VBool(a1.isTrue() && a2.isTrue()))
                 }
                 O_OR -> {
                     val (a2, a1) = popTwo()
-                    if (a1 is VBool && a2 is VBool) push(VBool(a1.v || a2.v))
-                    else fail(E_TYPE, "cannot OR ${a1.type} and ${a2.type}")
+                    push(VBool(a1.isTrue() || a2.isTrue()))
                 }
                 O_IN -> {
                     val (a2, a1) = popTwo()

--- a/src/test/kotlin/LangTest.kt
+++ b/src/test/kotlin/LangTest.kt
@@ -152,13 +152,16 @@ class LangTest: YeggTest() {
     }
 
     @Test
-    fun `Logical OR short circuits right side`() = yeggTest {
+    fun `Logical OR and AND short circuits right side`() = yeggTest {
         runForOutput($$"""
-            true || notifyConn("Success.")
-            false || notifyConn("FAILURE!")
+            true || notifyConn("FAILED 1")
+            true && notifyConn("OK 1.")
+            false && notifyConn("FAILED 2")
+            false || notifyConn("OK 2.")
             notifyConn("Done.")
         """, """
-            Success.
+            OK 1.
+            OK 2.
             Done.
         """)
     }

--- a/src/test/kotlin/LangTest.kt
+++ b/src/test/kotlin/LangTest.kt
@@ -151,4 +151,16 @@ class LangTest: YeggTest() {
         """)
     }
 
+    @Test
+    fun `Logical OR short circuits right side`() = yeggTest {
+        runForOutput($$"""
+            true || notifyConn("Success.")
+            false || notifyConn("FAILURE!")
+            notifyConn("Done.")
+        """, """
+            Success.
+            Done.
+        """)
+    }
+
 }


### PR DESCRIPTION
I realized that in my naive implementation, OR / AND won't short-circuit evaluation of the right-side expressions.  This makes it so.
