### PR TITLE
Assert types in list destructure

### DIFF
--- a/src/main/kotlin/compiler/ast/statement/N_DESTRUCT.kt
+++ b/src/main/kotlin/compiler/ast/statement/N_DESTRUCT.kt
@@ -3,17 +3,25 @@ package com.dlfsystems.yegg.compiler.ast.statement
 import com.dlfsystems.yegg.compiler.Coder
 import com.dlfsystems.yegg.compiler.ast.expr.N_EXPR
 import com.dlfsystems.yegg.compiler.ast.expr.identifier.N_IDENTIFIER
+import com.dlfsystems.yegg.value.VInt
 import com.dlfsystems.yegg.value.VString
+import com.dlfsystems.yegg.value.VVoid
 import com.dlfsystems.yegg.vm.Opcode.O_DESTRUCT
 import com.dlfsystems.yegg.vm.Opcode.O_VAL
 
-class N_DESTRUCT(val vars: List<N_IDENTIFIER>, val right: N_EXPR): N_STATEMENT() {
+class N_DESTRUCT(
+    val vars: List<N_IDENTIFIER>,
+    val types: List<Int>,
+    val right: N_EXPR
+): N_STATEMENT() {
     override fun toString() = "[${vars.joinToString(",")}] = $right"
     override fun kids() = vars + listOf(right)
 
     override fun code(c: Coder) = with (c.use(this)) {
         opcode(O_VAL)
         value(vars.map { VString(it.name) })
+        opcode(O_VAL)
+        value(types.map { VInt(it) })
         code(right)
         opcode(O_DESTRUCT)
     }

--- a/src/main/kotlin/compiler/ast/statement/N_DESTRUCT.kt
+++ b/src/main/kotlin/compiler/ast/statement/N_DESTRUCT.kt
@@ -5,7 +5,6 @@ import com.dlfsystems.yegg.compiler.ast.expr.N_EXPR
 import com.dlfsystems.yegg.compiler.ast.expr.identifier.N_IDENTIFIER
 import com.dlfsystems.yegg.value.VInt
 import com.dlfsystems.yegg.value.VString
-import com.dlfsystems.yegg.value.VVoid
 import com.dlfsystems.yegg.vm.Opcode.O_DESTRUCT
 import com.dlfsystems.yegg.vm.Opcode.O_VAL
 

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -64,13 +64,15 @@ class VM(
 
 
     init {
-        exe.getInitialVars(args).forEach { (name, v) -> initVar(name, v) }
-        initVar("args", VList.make(args))
-        initVar("this", c.vThis)
-        initVar("user", c.vUser)
+        exe.getInitialVars(args).forEach { (name, v) ->
+            setVar(name, v)
+        }
+        setVar("args", VList.make(args))
+        setVar("this", c.vThis)
+        setVar("user", c.vUser)
     }
 
-    private fun initVar(name: String, value: Value) {
+    private fun setVar(name: String, value: Value) {
         exe.symbols[name]?.also { variables[it] = value }
     }
 
@@ -336,7 +338,7 @@ class VM(
                             val t = Value.Type.entries[ti]
                             if (s.type != t) fail(E_INVARG, "${s.type} is not $t")
                         }
-                        exe.symbols[(vn as VString).v]?.also { variables[it] = s }
+                        setVar((vn as VString).v, s)
                     }
                 }
 

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -327,11 +327,17 @@ class VM(
                     } ?: fail(E_VARNF, "variable not found")
                 }
                 O_DESTRUCT -> {
-                    val (a2, a1) = popTwo()
-                    if (a2 !is VList) fail(E_TYPE, "cannot destructure from non-list")
-                    if ((a2 as VList).v.size < (a1 as VList).v.size) fail(E_RANGE, "missing args")
-                    a1.v.forEachIndexed { i, vn ->
-                        exe.symbols[(vn as VString).v]?.also { variables[it] = a2.v[i] }
+                    val (source, types, vars) = popThree()
+                    if (source !is VList) fail(E_TYPE, "cannot destructure from non-list")
+                    if ((source as VList).v.size < (vars as VList).v.size) fail(E_RANGE, "missing args")
+                    vars.v.forEachIndexed { i, vn ->
+                        val s = source.v[i]
+                        val ti = ((types as VList).v[i] as VInt).v
+                        if (ti > -1) {
+                            val t = Value.Type.entries[ti]
+                            if (s.type != t) fail(E_INVARG, "${s.type} is not $t")
+                        }
+                        exe.symbols[(vn as VString).v]?.also { variables[it] = s }
                     }
                 }
 

--- a/src/test/kotlin/LangTest.kt
+++ b/src/test/kotlin/LangTest.kt
@@ -233,4 +233,24 @@ class LangTest: YeggTest() {
             cheese
         """)
     }
+
+    @Test
+    fun `List destructure with types`() = yeggTest {
+        verb("sys", "looseFun", $$"""
+            [foo, bar] = args
+            notifyConn("loose $foo and $bar")
+        """)
+        verb("sys", "tightFun", $$"""
+            [foo: FLOAT, bar: STRING] = args
+            notifyConn("tight $foo and $bar")
+        """)
+
+        runForOutput($$"""
+            $sys.looseFun(12.6, 74)
+            $sys.tightFun(12.6, 74)
+        """, """
+            loose 12.6 and 74
+            E_INVARG: INT is not STRING
+        """)
+    }
 }


### PR DESCRIPTION
Adds optional type syntax to list destructuring:

[foo: INT, bar: FLOAT] = someList

When the destructure is executed, if the assigned values aren't of the specified types E_INVARG is thrown.