### PR TITLE
Void and Null

### DIFF
--- a/src/main/kotlin/compiler/TypeSpec.kt
+++ b/src/main/kotlin/compiler/TypeSpec.kt
@@ -33,13 +33,14 @@ data class TypeSpec(
         private const val NULLABLE_MULT = 1000
 
         // Decode from a VInt at runtime.
-        fun fromVInt(vi: VInt) =
-            if (vi.v == -1)
+        fun fromVInt(vi: VInt) = when {
+            vi.v == -1 ->
                 TypeSpec()
-            else if (vi.v >= NULLABLE_MULT)
+            vi.v >= NULLABLE_MULT ->
                 TypeSpec(Value.Type.entries[vi.v - NULLABLE_MULT], true)
-            else
+            else ->
                 TypeSpec(Value.Type.entries[vi.v], false)
+        }
     }
 
 }

--- a/src/main/kotlin/compiler/TypeSpec.kt
+++ b/src/main/kotlin/compiler/TypeSpec.kt
@@ -1,0 +1,47 @@
+package com.dlfsystems.yegg.compiler
+
+import com.dlfsystems.yegg.value.VInt
+import com.dlfsystems.yegg.value.VNull
+import com.dlfsystems.yegg.value.Value
+
+
+// A value type specifier.
+
+data class TypeSpec(
+    // Index into Value.Type.entries (null for ANY).
+    val i: Int? = null,
+    // Is null allowed instead of the type?
+    val nullable: Boolean? = null,
+) {
+
+    override fun toString() = i?.let {
+        Value.Type.entries[it].toString() + if (nullable == true) "?" else ""
+    } ?: "ANY"
+
+    // Does the given value match this type?
+    fun matches(v: Value) =
+        (i == null) ||
+        (nullable == true && v == VNull) ||
+        (v.type == Value.Type.entries[i])
+
+    // Encode to a VInt for inclusion in VM code.
+    fun toVInt() = VInt(
+        (i ?: -1) +
+        (if (nullable == true) NULLABLE_MULT else 0)
+    )
+
+
+    companion object {
+        private const val NULLABLE_MULT = 1000
+
+        // Decode from a VInt at runtime.
+        fun fromVInt(vi: VInt): TypeSpec {
+            if (vi.v == -1) return TypeSpec()
+            return if (vi.v >= NULLABLE_MULT)
+                TypeSpec(vi.v - NULLABLE_MULT, true)
+            else
+                TypeSpec(vi.v, false)
+        }
+    }
+
+}

--- a/src/main/kotlin/compiler/ast/expr/N_BINOP.kt
+++ b/src/main/kotlin/compiler/ast/expr/N_BINOP.kt
@@ -59,8 +59,6 @@ class N_MODULUS(left: N_EXPR, right: N_EXPR): N_BINOP("%", left, right, listOf(O
 
 class N_IN(left: N_EXPR, right: N_EXPR): N_BINOP("in", left, right, listOf(O_IN))
 
-class N_NULLCOAL(left: N_EXPR, right: N_EXPR): N_BINOP("?:", left, right, listOf(O_NULLCOAL))
-
 class N_CMP_EQ(left: N_EXPR, right: N_EXPR): N_BINOP("==", left, right, listOf(O_CMP_EQ))
 class N_CMP_NEQ(left: N_EXPR, right: N_EXPR): N_BINOP("!=", left, right, listOf(O_CMP_EQ, O_NEGATE))
 class N_CMP_GT(left: N_EXPR, right: N_EXPR): N_BINOP(">", left, right, listOf(O_CMP_GT))
@@ -96,5 +94,15 @@ class N_OR(left: N_EXPR, right: N_EXPR): N_BINOP("||", left, right, listOf()) {
         opcode(O_VAL)
         value(true)
         setForwardJump("orend")
+    }
+}
+
+class N_NULLCOAL(left: N_EXPR, right: N_EXPR): N_BINOP("?:", left, right, listOf()) {
+    override fun code(c: Coder) = with (c.use(this)) {
+        code(left)
+        opcode(O_IFNON)
+        jumpForward("nullskip")
+        code(right)
+        setForwardJump("nullskip")
     }
 }

--- a/src/main/kotlin/compiler/ast/expr/N_BINOP.kt
+++ b/src/main/kotlin/compiler/ast/expr/N_BINOP.kt
@@ -96,13 +96,3 @@ class N_OR(left: N_EXPR, right: N_EXPR): N_BINOP("||", left, right, listOf()) {
         setForwardJump("orend")
     }
 }
-
-class N_NULLCOAL(left: N_EXPR, right: N_EXPR): N_BINOP("?:", left, right, listOf()) {
-    override fun code(c: Coder) = with (c.use(this)) {
-        code(left)
-        opcode(O_IFNON)
-        jumpForward("nullskip")
-        code(right)
-        setForwardJump("nullskip")
-    }
-}

--- a/src/main/kotlin/compiler/ast/expr/N_BINOP.kt
+++ b/src/main/kotlin/compiler/ast/expr/N_BINOP.kt
@@ -59,6 +59,8 @@ class N_MODULUS(left: N_EXPR, right: N_EXPR): N_BINOP("%", left, right, listOf(O
 
 class N_IN(left: N_EXPR, right: N_EXPR): N_BINOP("in", left, right, listOf(O_IN))
 
+class N_NULLCOAL(left: N_EXPR, right: N_EXPR): N_BINOP("?:", left, right, listOf(O_NULLCOAL))
+
 class N_CMP_EQ(left: N_EXPR, right: N_EXPR): N_BINOP("==", left, right, listOf(O_CMP_EQ))
 class N_CMP_NEQ(left: N_EXPR, right: N_EXPR): N_BINOP("!=", left, right, listOf(O_CMP_EQ, O_NEGATE))
 class N_CMP_GT(left: N_EXPR, right: N_EXPR): N_BINOP(">", left, right, listOf(O_CMP_GT))

--- a/src/main/kotlin/compiler/ast/expr/N_NULLCOAL.kt
+++ b/src/main/kotlin/compiler/ast/expr/N_NULLCOAL.kt
@@ -1,0 +1,15 @@
+package com.dlfsystems.yegg.compiler.ast.expr
+
+import com.dlfsystems.yegg.compiler.Coder
+import com.dlfsystems.yegg.vm.Opcode.O_IFNON
+
+
+class N_NULLCOAL(left: N_EXPR, right: N_EXPR): N_BINOP("?:", left, right, listOf()) {
+    override fun code(c: Coder) = with (c.use(this)) {
+        code(left)
+        opcode(O_IFNON)
+        jumpForward("nullskip")
+        code(right)
+        setForwardJump("nullskip")
+    }
+}

--- a/src/main/kotlin/compiler/ast/expr/literal/N_LITERAL.kt
+++ b/src/main/kotlin/compiler/ast/expr/literal/N_LITERAL.kt
@@ -19,6 +19,12 @@ abstract class N_LITERAL: N_EXPR() {
     }
 }
 
+class N_LITERAL_NULL(): N_LITERAL() {
+    override fun toString() = "null"
+    override fun codeValue(coder: Coder) { coder.value(VNull) }
+    override fun constantValue() = VNull
+}
+
 class N_LITERAL_BOOLEAN(val value: Boolean): N_LITERAL() {
     override fun toString() = if (value) "true" else "false"
     override fun codeValue(coder: Coder) { coder.value(value) }

--- a/src/main/kotlin/compiler/ast/statement/N_DESTRUCT.kt
+++ b/src/main/kotlin/compiler/ast/statement/N_DESTRUCT.kt
@@ -1,16 +1,16 @@
 package com.dlfsystems.yegg.compiler.ast.statement
 
 import com.dlfsystems.yegg.compiler.Coder
+import com.dlfsystems.yegg.compiler.TypeSpec
 import com.dlfsystems.yegg.compiler.ast.expr.N_EXPR
 import com.dlfsystems.yegg.compiler.ast.expr.identifier.N_IDENTIFIER
-import com.dlfsystems.yegg.value.VInt
 import com.dlfsystems.yegg.value.VString
 import com.dlfsystems.yegg.vm.Opcode.O_DESTRUCT
 import com.dlfsystems.yegg.vm.Opcode.O_VAL
 
 class N_DESTRUCT(
     val vars: List<N_IDENTIFIER>,
-    val types: List<Int>,
+    val types: List<TypeSpec>,
     val right: N_EXPR
 ): N_STATEMENT() {
     override fun toString() = "[${vars.joinToString(",")}] = $right"
@@ -20,7 +20,7 @@ class N_DESTRUCT(
         opcode(O_VAL)
         value(vars.map { VString(it.name) })
         opcode(O_VAL)
-        value(types.map { VInt(it) })
+        value(types.map { it.toVInt() })
         code(right)
         opcode(O_DESTRUCT)
     }

--- a/src/main/kotlin/compiler/parser/Lexer.kt
+++ b/src/main/kotlin/compiler/parser/Lexer.kt
@@ -136,6 +136,10 @@ class Lexer(val source: String) {
             T_OBJREF -> {
                 if (isIDChar(c)) accumulate(c) else emit(T_OBJREF, c)
             }
+            T_ELVIS -> when (c) {
+                ':' -> emit(T_ELVIS)
+                else -> emit(T_QUESTION, c)
+            }
             T_IDENTIFIER -> {
                 if (isIdentifierChar(c)) accumulate(c) else emit(T_IDENTIFIER, c)
             }
@@ -158,6 +162,7 @@ class Lexer(val source: String) {
                     '|' -> begin(T_LOGIC_OR)
                     '&' -> begin(T_LOGIC_AND)
                     '.' -> begin(T_DOT)
+                    '?' -> begin(T_ELVIS)
                     '(' -> emit(T_PAREN_OPEN)
                     ')' -> emit(T_PAREN_CLOSE)
                     '[' -> emit(T_BRACKET_OPEN)
@@ -167,7 +172,6 @@ class Lexer(val source: String) {
                     ';' -> emit(T_SEMICOLON)
                     '$' -> emit(T_DOLLAR)
                     ',' -> emit(T_COMMA)
-                    '?' -> emit(T_QUESTION)
                     '^' -> emit(T_POWER)
                     '%' -> emit(T_MODULUS)
                     '\'' -> emit(T_TICK)

--- a/src/main/kotlin/compiler/parser/Parser.kt
+++ b/src/main/kotlin/compiler/parser/Parser.kt
@@ -705,6 +705,7 @@ class Parser(inputTokens: List<Token>) {
     // Parse a bare value (a literal, or a variable identifier)
     private fun pValue(): N_EXPR? {
         val next = this::pCollection
+        consume(T_NULL)?.also { return node(N_LITERAL_NULL()) }
         consume(T_STRING)?.also { return node(N_LITERAL_STRING(it.string)) }
         consume(T_INTEGER)?.also { return node(N_LITERAL_INTEGER(it.string.toInt())) }
         consume(T_FLOAT)?.also { return node(N_LITERAL_FLOAT(it.string.toFloat())) }

--- a/src/main/kotlin/compiler/parser/Parser.kt
+++ b/src/main/kotlin/compiler/parser/Parser.kt
@@ -342,10 +342,9 @@ class Parser(inputTokens: List<Token>) {
                     consume(T_COLON)?.also {
                         val typeName = consume(T_IDENTIFIER)!!.string
                         val nullable = consume(T_QUESTION) != null
-                        Value.Type.entries.indexOfFirst { it.name == typeName }.also { i ->
-                            if (i == -1) fail("$typeName is not a type")
-                            types.add(TypeSpec(i, nullable))
-                        }
+                        Value.Type.entries.firstOrNull { it.name == typeName }?.also {
+                            types.add(TypeSpec(it, nullable))
+                        } ?: fail("$typeName is not a type")
                     } ?: run {
                         types.add(TypeSpec())
                     }

--- a/src/main/kotlin/compiler/parser/Parser.kt
+++ b/src/main/kotlin/compiler/parser/Parser.kt
@@ -468,7 +468,7 @@ class Parser(inputTokens: List<Token>) {
 
     // Parse: <expr> and|or <expr>
     private fun pAndOr(): N_EXPR? {
-        val next = this::pConditional
+        val next = this::pNullCoalesce
         var left = next() ?: return null
         while (nextIs(T_LOGIC_AND, T_LOGIC_OR)) {
             val operator = consume()
@@ -476,6 +476,18 @@ class Parser(inputTokens: List<Token>) {
                 left = node(if (operator.type == T_LOGIC_AND) N_AND(left, right)
                             else N_OR(left, right)
                 )
+            }
+        }
+        return left
+    }
+
+    // Parse: <expr> ?: <expr>
+    private fun pNullCoalesce(): N_EXPR? {
+        val next = this::pConditional
+        var left = next() ?: return null
+        consume(T_ELVIS)?.also {
+            next()?.also { right ->
+                left = node(N_NULLCOAL(left, right))
             }
         }
         return left

--- a/src/main/kotlin/compiler/parser/Token.kt
+++ b/src/main/kotlin/compiler/parser/Token.kt
@@ -51,6 +51,7 @@ data class Token(
         T_ARROW("->"),
         T_TICK("'"),
         T_BACKTICK("`"),
+        T_ELVIS("?:"),
 
         // Literals
         T_IDENTIFIER("ident"),

--- a/src/main/kotlin/compiler/parser/Token.kt
+++ b/src/main/kotlin/compiler/parser/Token.kt
@@ -80,6 +80,7 @@ data class Token(
         T_CONTINUE("continue", true),
         T_TRY("try", true),
         T_CATCH("catch", true),
+        T_NULL("null", true),
 
         T_EOF("EOF");
     }

--- a/src/main/kotlin/value/VList.kt
+++ b/src/main/kotlin/value/VList.kt
@@ -234,7 +234,7 @@ data class VList(var v: MutableList<Value> = mutableListOf()): Value() {
                 if (it.isTrue()) return ele
             }
         }
-        return VVoid
+        return VNull
     }
 
     private fun verbFilter(c: Context, args: List<Value>): Value {

--- a/src/main/kotlin/value/VMap.kt
+++ b/src/main/kotlin/value/VMap.kt
@@ -75,7 +75,7 @@ data class VMap(val v: MutableMap<Value, Value>): Value() {
             v.remove(args[0])
             return removed!!
         }
-        return VVoid
+        return VNull
     }
 
 

--- a/src/main/kotlin/value/VNull.kt
+++ b/src/main/kotlin/value/VNull.kt
@@ -1,0 +1,19 @@
+package com.dlfsystems.yegg.value
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("VNull")
+data object VNull: Value() {
+
+    @SerialName("yType")
+    override val type = Type.NULL
+
+    override fun toString() = "null"
+
+    override fun cmpEq(a2: Value) = a2 == this
+    override fun cmpGt(a2: Value) = a2 != this
+    override fun cmpGe(a2: Value) = a2 == this
+
+}

--- a/src/main/kotlin/value/VNull.kt
+++ b/src/main/kotlin/value/VNull.kt
@@ -1,5 +1,6 @@
 package com.dlfsystems.yegg.value
 
+import com.dlfsystems.yegg.server.Yegg
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,6 +13,7 @@ data object VNull: Value() {
 
     override fun toString() = "null"
 
+    override fun negate() = Yegg.vTrue
     override fun cmpEq(a2: Value) = a2 == this
     override fun cmpGt(a2: Value) = a2 != this
     override fun cmpGe(a2: Value) = a2 == this

--- a/src/main/kotlin/value/VVoid.kt
+++ b/src/main/kotlin/value/VVoid.kt
@@ -11,13 +11,5 @@ data object VVoid: Value() {
     override val type = Type.VOID
 
     override fun toString() = "<VOID>"
-    override fun asString() = ""
-
-    override fun cmpEq(a2: Value): Boolean = a2 is VVoid
-
-    override fun getProp(name: String) = when (name) {
-        "asString" -> VString(asString())
-        else -> null
-    }
 
 }

--- a/src/main/kotlin/value/Value.kt
+++ b/src/main/kotlin/value/Value.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 sealed class Value {
-    enum class Type { VOID, BOOL, INT, FLOAT, STRING, LIST, MAP, OBJ, TRAIT, FUN, TASK, ERR }
+    enum class Type { VOID, NULL, BOOL, INT, FLOAT, STRING, LIST, MAP, OBJ, TRAIT, FUN, TASK, ERR }
 
     @SerialName("yType")
     abstract val type: Type

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -37,6 +37,9 @@ enum class Opcode(val argCount: Int = 0) {
     // Jump to arg1 address if pop0 is false.
     O_IF(1),
 
+    // Jump to arg1 address if peek0 is non-null, otherwise pop the null.
+    O_IFNON(1),
+
     // Jump to arg1 address.
     O_JUMP(1),
 
@@ -114,7 +117,6 @@ enum class Opcode(val argCount: Int = 0) {
     // Push the boolean result of pop0 and pop1.
     O_IN,
     O_ISTRAIT,
-    O_NULLCOAL,
     O_CMP_EQ,
     O_CMP_GT,
     O_CMP_GE,

--- a/src/main/kotlin/vm/Opcode.kt
+++ b/src/main/kotlin/vm/Opcode.kt
@@ -114,6 +114,7 @@ enum class Opcode(val argCount: Int = 0) {
     // Push the boolean result of pop0 and pop1.
     O_IN,
     O_ISTRAIT,
+    O_NULLCOAL,
     O_CMP_EQ,
     O_CMP_GT,
     O_CMP_GE,

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -195,6 +195,10 @@ class VM(
                     val condition = pop()
                     if (condition.isFalse()) pc = elseAddr
                 }
+                O_IFNON -> {
+                    val elseAddr = next().address!!
+                    if (peek() == VNull) pop() else pc = elseAddr
+                }
                 O_IFVAREQ -> {
                     val varID = next().intFromV
                     val elseAddr = next().address!!
@@ -400,10 +404,6 @@ class VM(
                     val target = pop()
                     val typeID = next().value!!
                     push(VBool(target.type == Value.Type.entries[(typeID as VInt).v]))
-                }
-                O_NULLCOAL -> {
-                    val (default, source) = popTwo()
-                    push(if (source == VNull) default else source)
                 }
                 O_CMP_EQ, O_CMP_GT, O_CMP_GE, O_CMP_LT, O_CMP_LE -> {
                     val (a2, a1) = popTwo()

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -55,7 +55,9 @@ class VM(
 
     private inline fun push(v: Value) = stack.addFirst(v)
     private inline fun peek() = stack.first()
-    private inline fun pop() = stack.removeFirst().also { if (it.type == Value.Type.VOID) fail(E_VOID, "void in expression") }
+    private inline fun pop() = stack.removeFirst().also {
+        if (it.type == Value.Type.VOID) fail(E_VOID, "void in expression")
+    }
     private inline fun popTwo() = listOf(pop(), pop())
     private inline fun popThree() = listOf(pop(), pop(), pop())
     private inline fun popFour() = listOf(pop(), pop(), pop(), pop())

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -54,10 +54,10 @@ class VM(
 
     private inline fun push(v: Value) = stack.addFirst(v)
     private inline fun peek() = stack.first()
-    private inline fun pop() = stack.removeFirst()
-    private inline fun popTwo() = listOf(stack.removeFirst(), stack.removeFirst())
-    private inline fun popThree() = listOf(stack.removeFirst(), stack.removeFirst(), stack.removeFirst())
-    private inline fun popFour() = listOf(stack.removeFirst(), stack.removeFirst(), stack.removeFirst(), stack.removeFirst())
+    private inline fun pop() = stack.removeFirst().also { if (it.type == Value.Type.VOID) fail(E_VOID, "void in expression") }
+    private inline fun popTwo() = listOf(pop(), pop())
+    private inline fun popThree() = listOf(pop(), pop(), pop())
+    private inline fun popFour() = listOf(pop(), pop(), pop(), pop())
     private inline fun next() = exe.code[pc++]
 
     override fun toString() = "$exe"
@@ -127,7 +127,7 @@ class VM(
             when (word.opcode) {
 
                 O_DISCARD -> {
-                    if (stack.isNotEmpty()) exprValue = pop()
+                    if (stack.isNotEmpty()) exprValue = stack.removeFirst()
                 }
 
                 // Value ops

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -3,6 +3,7 @@
 package com.dlfsystems.yegg.vm
 
 import com.dlfsystems.yegg.compiler.CodePos
+import com.dlfsystems.yegg.compiler.TypeSpec
 import com.dlfsystems.yegg.server.mcp.MCP
 import com.dlfsystems.yegg.server.Yegg
 import com.dlfsystems.yegg.server.mcp.Task
@@ -332,11 +333,8 @@ class VM(
                     if ((source as VList).v.size < (vars as VList).v.size) fail(E_RANGE, "missing args")
                     vars.v.forEachIndexed { i, vn ->
                         val s = source.v[i]
-                        val ti = ((types as VList).v[i] as VInt).v
-                        if (ti > -1) {
-                            val t = Value.Type.entries[ti]
-                            if (s.type != t) fail(E_INVARG, "${s.type} is not $t")
-                        }
+                        val type = TypeSpec.fromVInt((types as VList).v[i] as VInt)
+                        if (!type.matches(s)) fail(E_TYPE, "${s.type} is not $type")
                         setVar((vn as VString).v, s)
                     }
                 }

--- a/src/main/kotlin/vm/VM.kt
+++ b/src/main/kotlin/vm/VM.kt
@@ -403,6 +403,10 @@ class VM(
                     val typeID = next().value!!
                     push(VBool(target.type == Value.Type.entries[(typeID as VInt).v]))
                 }
+                O_NULLCOAL -> {
+                    val (default, source) = popTwo()
+                    push(if (source == VNull) default else source)
+                }
                 O_CMP_EQ, O_CMP_GT, O_CMP_GE, O_CMP_LT, O_CMP_LE -> {
                     val (a2, a1) = popTwo()
                     when (word.opcode) {

--- a/src/main/kotlin/vm/VMException.kt
+++ b/src/main/kotlin/vm/VMException.kt
@@ -48,6 +48,9 @@ class VMException(val type: Type, val m: String): Exception() {
         // Callstack recursion limit exceeded
         E_MAXREC,
 
+        // void value generated in expression
+        E_VOID,
+
         // Other system failures
         E_SYS,
 

--- a/src/test/kotlin/LangTest.kt
+++ b/src/test/kotlin/LangTest.kt
@@ -250,7 +250,7 @@ class LangTest: YeggTest() {
             $sys.tightFun(12.6, 74)
         """, """
             loose 12.6 and 74
-            E_INVARG: INT is not STRING
+            E_TYPE: INT is not STRING
         """)
     }
 

--- a/src/test/kotlin/NullTest.kt
+++ b/src/test/kotlin/NullTest.kt
@@ -1,0 +1,37 @@
+package com.dlfsystems.yegg
+
+import com.dlfsystems.yegg.util.YeggTest
+import kotlin.test.Test
+
+class NullTest: YeggTest() {
+
+    @Test
+    fun `No void expressions`() = yeggTest {
+        runForOutput($$"""
+            foo = cnotify("returns void")
+            cnotify("OH NO!  $foo")
+        """, """
+            returns void
+            E_VOID: void in expression
+        """)
+    }
+
+    @Test
+    fun `Null type args and coalesce`() = yeggTest {
+        verb("sys", "weightOf", $$"""
+            [foo: STRING?] = args
+            return (foo ?: "default").length
+        """)
+        runForOutput($$"""
+            for (x in ["egg", null, "beer", 5]) {
+                w = $sys.weightOf(x)
+                cnotify("$x weighs $w")
+            }
+        """, """
+            egg weighs 3
+            null weighs 7
+            beer weighs 4
+            E_TYPE: INT is not STRING
+        """)
+    }
+}


### PR DESCRIPTION
Thus far, Void has been the value representing both "this doesn't return a value" and "no value was returned".  An insightful PR reviewer a while back made me rethink this.

I decided to keep VVoid and add a separate VNull value:

- VVoid remains the return value for "things that don't return/shouldn't be in expressions".  This is now helpfully enforced by the VM; if you try to use a Void-producing expression, E_VOID is thrown.  This means void can never leak into a variable/property/etc.
- VNull is the return value for "things that might return something, but didn't in this case".  I changed two utility funs (List.first and Map.remove) to return null in their failure case.

Added null sugar:

- Literal 'null' value can be written in code.
- List destructuring allows nullable type assertions a la STRING?, INT?
- Elvis operator ( ?: ) for null coalescing expressions -- this short-circuits like and/or, i.e. the right side is not evaluated if the left is non-null.

The next plan is to add null-checking dot references so you can do:
```
foo = bar?.method() ?: default
```
and null-checked execution blocks:
```
bar?{
   doSomethings
}
```
but that'll come in a future PR.